### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/exploreborders/LocalRAG/security/code-scanning/2](https://github.com/exploreborders/LocalRAG/security/code-scanning/2)

To fix the problem, the workflow file (.github/workflows/ci.yml) should explicitly set a `permissions` block at the root level (applies to all jobs), or (less commonly) within individual jobs. The permission should follow the principle of least privilege, which for most CI use-cases is `contents: read`, unless more permission is required (e.g., for pull-requests, the `pull-requests: write` permission is commonly required). In this case, since there is no evidence the jobs require write permissions, we should add a minimal `permissions` block at the root level, right after the workflow name. This block will look like:

```yaml
permissions:
  contents: read
```

Add this under line 1 in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
