### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/exploreborders/LocalRAG/security/code-scanning/1](https://github.com/exploreborders/LocalRAG/security/code-scanning/1)

To fix this problem, we should add a `permissions:` block at either the root level of the workflow or at the beginning of each job. Since both jobs appear to be running tasks that generally only need read access to repository contents (and perhaps additional permissions if they interact with issues or pull requests), but no evidence of writing is shown in the snippet, a restrictive permission block with `contents: read` is the safest minimal initial setting.

The optimal fix is to insert the following at the top (after `name:` and before or after `on:`):

```yaml
permissions:
  contents: read
```

If in the future a job requires additional permission (e.g., to write checks, create deployments), that can be added at the job level. For now, set read-only at the workflow root so both jobs inherit minimal permissions unless otherwise specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
